### PR TITLE
Returns all instrument settings metadata including PMT

### DIFF
--- a/Cyz2Json/Program.cs
+++ b/Cyz2Json/Program.cs
@@ -1,42 +1,21 @@
-﻿//
-// Cyz2Json
-//
-// Convert CYZ flow cytometry files to a JSON format.
-//
-// Copyright(c) 2023 Centre for Environment, Fisheries and Aquaculture Science.
-//
-
-using CytoSense.Data;
+﻿using CytoSense.Data;
 using CytoSense.CytoSettings;
 using CytoSense.Data.ParticleHandling;
 using CytoSense.Data.ParticleHandling.Channel;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 using System.CommandLine;
-
-// Design decisions:
-//
-// We want to easily eyeball files so we choose JSON rather than a
-// binary format.
-//
-// We want all data in one file, so we include the images as base64
-// encoded chunks within the JSON rather than write them to separate
-// files.
-//
-// We don't use the Cytobuoy provided image crop, prefering to do that
-// ourselves later and giving us the option of other toolkits. This also
-// allows us to drop OpenCVSharp which seems problematic for cross
-// platform support.
+using System.Reflection;
 
 namespace Cyz2Json
 {
     internal class Program
     {
-
         static void Main(string[] args)
         {
             var inputArgument = new Argument<FileInfo>(
                 "input",
-            description: "CYZ input file");
+                description: "CYZ input file");
 
             var outputOption = new Option<FileInfo>(
                 "--output",
@@ -46,22 +25,24 @@ namespace Cyz2Json
                 name: "--raw",
                 description: "Do not apply the moving weighted average filtering algorithm to pulse shapes. Export raw, unsmoothed data.");
 
+            var verboseOption = new Option<bool>(
+                name: "--verbose",
+                description: "Save all possible measurement settings with your file (default: true)",
+                getDefaultValue: () => true);
+
             var rootCommand = new RootCommand("Convert CYZ files to JSON")
             {
-                inputArgument, outputOption, rawOption
+                inputArgument, outputOption, rawOption, verboseOption
             };
 
-            rootCommand.SetHandler(Convert, inputArgument, outputOption, rawOption);
+            rootCommand.SetHandler(Convert, inputArgument, outputOption, rawOption, verboseOption);
 
             rootCommand.Invoke(args);
         }
-        /// <summary>
-        /// Convert the flow cytometry data in the file designated by cyzFilename to Javscript Object Notation (JSON).
-        /// If jsonFilename is null, echo the JSON to the console, otherwise store it a file designated by jsonFilename.
-        /// </summary>
-        static void Convert(FileInfo cyzFilename, FileInfo jsonFilename, bool isRaw)
+
+        static void Convert(FileInfo cyzFilename, FileInfo jsonFilename, bool isRaw, bool verbose)
         {
-            var data = LoadData(cyzFilename.FullName, isRaw);
+            var data = LoadData(cyzFilename.FullName, isRaw, verbose);
 
             StreamWriter streamWriter;
 
@@ -80,10 +61,7 @@ namespace Cyz2Json
             streamWriter.Close();
         }
 
-        /// <summary>
-        /// Load all the flow cytometry data from the CYZ file designated by pathname.
-        /// </summary>
-        private static Dictionary<string, object> LoadData(string pathname, bool isRaw)
+        private static Dictionary<string, object> LoadData(string pathname, bool isRaw, bool verbose)
         {
             var data = new Dictionary<string, object>();
 
@@ -92,28 +70,77 @@ namespace Cyz2Json
             var dfw = new DataFileWrapper(pathname);
 
             dfw.CytoSettings.setChannelVisualisationMode(ChannelAccessMode.Optical_debugging);
-            ChannelData.VarLength = 13; // Calculate the alternate variable height length parameter at a height of 13%
-
-            // Some old files can have a problem where the pre-concentration
-            // measurement and the actual concentration during the measurement
-            // disagree.  If this happens and you try to use the data this will
-            // result in an exception.  You can check this beforehand, and force the
-            // use of one of the concentrations during the calculations.
+            ChannelData.VarLength = 13;
 
             double concentration = 0.0;
             double preconcentration = 0.0;
             if (dfw.CheckConcentration(ref concentration, ref preconcentration))
             {
-                // In this case usually the pre-concentration is the correct one, so we use that.
-
                 Console.WriteLine("WARNING: concentration measurement disagrees with pre-concentration measurement. Using the latter.");
                 dfw.ConcentrationMode = ConcentrationModeEnum.Pre_measurement_FTDI;
             }
-            data["instrument"] = LoadInstrument(dfw);
+            data["instrument"] = LoadInstrument(dfw, verbose);
             data["particles"] = LoadParticles(dfw, isRaw);
             data["images"] = LoadImages(dfw);
 
             return data;
+        }
+
+        private static Dictionary<string, object> LoadInstrument(DataFileWrapper dfw, bool verbose)
+        {
+            var instrument = new Dictionary<string, object>();
+
+            instrument["name"] = dfw.CytoSettings.name;
+            instrument["serialNumber"] = dfw.CytoSettings.SerialNumber;
+            instrument["sampleCoreSpeed"] = dfw.CytoSettings.SampleCorespeed;
+            instrument["laserBeamWidth"] = dfw.CytoSettings.LaserBeamWidth;
+            instrument["channels"] = LoadChannels(dfw);
+            instrument["measurementSettings"] = LoadMeasurementSettings(dfw, verbose);
+            instrument["measurementResults"] = LoadMeasurementResults(dfw);
+
+            return instrument;
+        }
+
+        private static Dictionary<string, object> LoadMeasurementSettings(DataFileWrapper dfw, bool verbose)
+        {
+            if (verbose)
+            {
+                var measurementInstrumentSettings = new Dictionary<string, object>();
+
+                var settings = new JsonSerializerSettings
+                {
+                    ContractResolver = new IgnoreErrorPropertiesResolver(),
+                    Error = (sender, args) =>
+                    {
+                        args.ErrorContext.Handled = true;
+                    }
+                };
+
+                var cytoSettingsJson = JsonConvert.SerializeObject(dfw.MeasurementSettings, settings);
+                var cytoSettings = JsonConvert.DeserializeObject(cytoSettingsJson);
+
+                measurementInstrumentSettings["CytoSettings"] = cytoSettings;
+
+                return measurementInstrumentSettings;
+            }
+            else
+            {
+                var measurementSettings = new Dictionary<string, object>();
+
+                measurementSettings["name"] = dfw.MeasurementSettings.TabName;
+                measurementSettings["duration"] = dfw.MeasurementSettings.StopafterTimertext;
+                measurementSettings["pumpSpeed"] = dfw.MeasurementSettings.ConfiguredSamplePompSpeed;
+                measurementSettings["triggerChannel"] = dfw.MeasurementSettings.TriggerChannel;
+                measurementSettings["triggerLevel"] = dfw.MeasurementSettings.TriggerLevel1e;
+                measurementSettings["smartTrigger"] = dfw.MeasurementSettings.SmartTriggeringEnabled;
+
+                if (dfw.MeasurementSettings.SmartTriggeringEnabled)
+                    measurementSettings["smartTriggerDescription"] = dfw.MeasurementSettings.SmartTriggerSettingDescription;
+
+                measurementSettings["takeImages"] = dfw.MeasurementSettings.IIFCheck;
+
+                return measurementSettings;
+            }
         }
 
         private static List<Dictionary<string, object>> LoadParticles(DataFileWrapper dfw, bool isRaw)
@@ -128,13 +155,10 @@ namespace Cyz2Json
 
         private static Dictionary<string, object> LoadParticle(Particle particle, bool isRaw)
         {
-
             var particleData = new Dictionary<string, object>();
 
             particleData["particleId"] = particle.ID;
             particleData["hasImage"] = particle.hasImage;
-
-            // Pulse shapes
 
             var pulseShapes = new List<Dictionary<string, object>>();
 
@@ -153,8 +177,6 @@ namespace Cyz2Json
             }
 
             particleData["pulseShapes"] = pulseShapes;
-
-            // Parameters
 
             var parameters = new List<Dictionary<string, object>>();
 
@@ -188,49 +210,6 @@ namespace Cyz2Json
             return particleData;
         }
 
-        private static Dictionary<string, object> LoadMeasurementSettings(DataFileWrapper dfw)
-        {
-            var measurementSettings = new Dictionary<string, object>();
-
-            measurementSettings["name"] = dfw.MeasurementSettings.TabName;
-            measurementSettings["duration"] = dfw.MeasurementSettings.StopafterTimertext; // seconds
-            measurementSettings["pumpSpeed"] = dfw.MeasurementSettings.ConfiguredSamplePompSpeed; // muL/s
-            measurementSettings["triggerChannel"] = dfw.MeasurementSettings.TriggerChannel;
-            measurementSettings["triggerLevel"] = dfw.MeasurementSettings.TriggerLevel1e;
-            measurementSettings["smartTrigger"] = dfw.MeasurementSettings.SmartTriggeringEnabled;
-
-            if (dfw.MeasurementSettings.SmartTriggeringEnabled)
-                measurementSettings["smartTriggerDescription"] = dfw.MeasurementSettings.SmartTriggerSettingDescription;
-
-            measurementSettings["takeImages"] = dfw.MeasurementSettings.IIFCheck;
-
-            return measurementSettings;
-        }
-
-        private static Dictionary<string, object> LoadMeasurementResults(DataFileWrapper dfw)
-        {
-            var measurementResults = new Dictionary<string, object>();
-
-            measurementResults["start"] = dfw.MeasurementInfo.MeasurementStart;
-
-            measurementResults["duration"] = dfw.MeasurementInfo.ActualMeasureTime;
-            measurementResults["particleCount"] = dfw.MeasurementInfo.NumberofCountedParticles;
-            measurementResults["particlesInFileCount"] = dfw.MeasurementInfo.NumberofSavedParticles;
-            measurementResults["pictureCount"] = dfw.MeasurementInfo.NumberOfPictures;
-            measurementResults["pumpedVolume"] = dfw.pumpedVolume; // muL
-            measurementResults["analysedVolume"] = dfw.analyzedVolume; // muL
-            measurementResults["particleConcentration"] = dfw.Concentration; // n/muL
-
-            // Auxiliary Sensor Data
-
-            measurementResults["systemTemperature"] = dfw.MeasurementInfo.SystemTemp; // C
-            measurementResults["sheathTemperature"] = dfw.MeasurementInfo.SheathTemp; // C
-            measurementResults["absolutePressure"] = dfw.MeasurementInfo.ABSPressure; // mbar
-            measurementResults["differentialPressure"] = dfw.MeasurementInfo.DiffPressure; // mbar
-
-            return measurementResults;
-        }
-
         private static List<Dictionary<string, object>> LoadChannels(DataFileWrapper dfw)
         {
             var channels = new List<Dictionary<string, object>>();
@@ -247,19 +226,28 @@ namespace Cyz2Json
             return channels;
         }
 
-        private static Dictionary<string, object> LoadInstrument(DataFileWrapper dfw)
+        private static Dictionary<string, object> LoadMeasurementResults(DataFileWrapper dfw)
         {
-            var instrument = new Dictionary<string, object>();
+            var measurementResults = new Dictionary<string, object>();
 
-            instrument["name"] = dfw.CytoSettings.name;
-            instrument["serialNumber"] = dfw.CytoSettings.SerialNumber;
-            instrument["sampleCoreSpeed"] = dfw.CytoSettings.SampleCorespeed;
-            instrument["laserBeamWidth"] = dfw.CytoSettings.LaserBeamWidth;
-            instrument["channels"] = LoadChannels(dfw);
-            instrument["measurementSettings"] = LoadMeasurementSettings(dfw);
-            instrument["measurementResults"] = LoadMeasurementResults(dfw);
+            measurementResults["start"] = dfw.MeasurementInfo.MeasurementStart;
 
-            return instrument;
+            measurementResults["duration"] = dfw.MeasurementInfo.ActualMeasureTime;
+            measurementResults["particleCount"] = dfw.MeasurementInfo.NumberofCountedParticles;
+            measurementResults["particlesInFileCount"] = dfw.MeasurementInfo.NumberofSavedParticles;
+            measurementResults["pictureCount"] = dfw.MeasurementInfo.NumberOfPictures;
+            measurementResults["pumpedVolume"] = dfw.pumpedVolume;
+            measurementResults["analysedVolume"] = dfw.analyzedVolume; // muL
+            measurementResults["particleConcentration"] = dfw.Concentration; // n/muL
+
+            // Auxiliary Sensor Data
+
+            measurementResults["systemTemperature"] = dfw.MeasurementInfo.SystemTemp; // C
+            measurementResults["sheathTemperature"] = dfw.MeasurementInfo.SheathTemp; // C
+            measurementResults["absolutePressure"] = dfw.MeasurementInfo.ABSPressure; // mbar
+            measurementResults["differentialPressure"] = dfw.MeasurementInfo.DiffPressure; // mbar
+
+            return measurementResults;
         }
 
         private static List<Dictionary<string, object>> LoadImages(DataFileWrapper dfw)
@@ -287,5 +275,27 @@ namespace Cyz2Json
             }
             return images;
         }
+
+        public class IgnoreErrorPropertiesResolver : DefaultContractResolver
+        {
+            protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+            {
+                var property = base.CreateProperty(member, memberSerialization);
+                property.ShouldSerialize = instance =>
+                {
+                    try
+                    {
+                        var value = property.ValueProvider.GetValue(instance);
+                        return true;
+                    }
+                    catch
+                    {
+                        return false;
+                    }
+                };
+                return property;
+            }
+        }
     }
 }
+			

--- a/Cyz2Json/Program.cs
+++ b/Cyz2Json/Program.cs
@@ -4,8 +4,8 @@
 // Convert CYZ flow cytometry files to a JSON format.
 //
 // Copyright(c) 2023 Centre for Environment, Fisheries and Aquaculture Science.
-//using CytoSense.Data;
-
+//
+using CytoSense.Data;
 using CytoSense.CytoSettings;
 using CytoSense.Data.ParticleHandling;
 using CytoSense.Data.ParticleHandling.Channel;


### PR DESCRIPTION
Returns the PMT levels as Veronique showed me them to be in cytoclus software (PMTlevelsString). This exports everything it can in measurementsettings by default. Use flag --metadatagreedy false to follow the old behaviour which selected specific dictionary objects from within this